### PR TITLE
Bump AtlasPack version to include amygdala/hippocampus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM pennlinc/xcp_d:0.1.3 as build_fsl
-FROM pennlinc/atlaspack:0.0.5 as atlaspack
+FROM pennlinc/atlaspack:0.1.0 as atlaspack
 FROM ubuntu:bionic-20220531
 
 COPY docker/files/neurodebian.gpg /usr/local/etc/neurodebian.gpg


### PR DESCRIPTION
Increases AtlasPack version from 0.0.5 to 0.1.0.