### PR TITLE
Remove Freesurfer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,42 +140,6 @@ ENV FSLDIR="/opt/fsl" \
     PATH="/opt/fsl/lib:/opt/fsl/bin:$PATH" \
     FSL_DEPS="libquadmath0;libnewimage.so;libmiscmaths.so"
 
-# Install FreeSurfer
-RUN curl -sSL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.1/freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz | tar zxv --no-same-owner -C /opt \
-    --exclude="freesurfer/diffusion" \
-    --exclude="freesurfer/docs" \
-    --exclude="freesurfer/fsfast" \
-    --exclude="freesurfer/lib/cuda" \
-    --exclude="freesurfer/lib/qt" \
-    --exclude="freesurfer/matlab" \
-    --exclude="freesurfer/mni/share/man" \
-    --exclude="freesurfer/subjects/fsaverage_sym" \
-    --exclude="freesurfer/subjects/fsaverage3" \
-    --exclude="freesurfer/subjects/fsaverage4" \
-    --exclude="freesurfer/subjects/cvs_avg35" \
-    --exclude="freesurfer/subjects/cvs_avg35_inMNI152" \
-    --exclude="freesurfer/subjects/bert" \
-    --exclude="freesurfer/subjects/lh.EC_average" \
-    --exclude="freesurfer/subjects/rh.EC_average" \
-    --exclude="freesurfer/subjects/sample-*.mgz" \
-    --exclude="freesurfer/subjects/V1_average" \
-    --exclude="freesurfer/trctrain"
-
-ENV FREESURFER_HOME="/opt/freesurfer" \
-    FSF_OUTPUT_FORMAT="nii.gz"
-
-ENV FUNCTIONALS_DIR="$FREESURFER_HOME/sessions" \
-    LOCAL_DIR="$FREESURFER_HOME/local" \
-    MINC_BIN_DIR="$FREESURFER_HOME/mni/bin" \
-    MINC_LIB_DIR="$FREESURFER_HOME/mni/lib" \
-    MNI_DIR="$FREESURFER_HOME/mni" \
-    MNI_DATAPATH="$FREESURFER_HOME/mni/data"
-
-ENV MNI_PERL5LIB="$MINC_LIB_DIR/perl5/5.8.5" \
-    PERL5LIB="$MINC_LIB_DIR/perl5/5.8.5" \
-    SUBJECTS_DIR="$FREESURFER_HOME/subjects" \
-    PATH="$FREESURFER_HOME/bin:$FREESURFER_HOME/tktools:$MINC_BIN_DIR:$PATH"
-
 # Install ANTS
 ENV ANTSPATH="/usr/lib/ants"
 RUN mkdir -p $ANTSPATH && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
         afni=18.0.05+git24-gb25b21054~dfsg.1-1~nd17.10+1+nd18.04+1 \
-        connectome-workbench=1.5.0-1~nd18.04+1 \
+        connectome-workbench=2.0.0-1~nd120+1 \
         git-annex-standalone && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
After https://github.com/PennLINC/xcp_d/pull/1273 and https://github.com/PennLINC/xcp_d/pull/1255, XCP-D no longer needs Freesurfer.