### PR TITLE
Downgrade workbench 2.0.0 --> 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN curl -sSL "http://neuro.debian.net/lists/$( lsb_release -c | cut -f2 ).us-ca
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-        connectome-workbench \
+        connectome-workbench=1.5.0-2 \
         git-annex-standalone && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
I was thinking 2.0.0 might be responsible for the weird ShowScene results we're seeing in XCP-D with non-normalized surfaces. See below, from the ds001419-cifti test

![image](https://github.com/user-attachments/assets/c45ef0f6-eb7d-422b-98b9-0f2a2f9d9712)
